### PR TITLE
End transaction only after processing the complete pipeline

### DIFF
--- a/redis/server.go
+++ b/redis/server.go
@@ -300,6 +300,7 @@ func (c *client) processInput() {
 	curr := 0       // curr pos of processing
 	finish := false // finish processing a query
 	for {
+		c.tx.Begin()
 		n, err := c.conn.Read(c.querybuf[pos:])
 		if err != nil { // TODO: check error
 			fmt.Println("Reading from client:", err)
@@ -338,6 +339,7 @@ func (c *client) processInput() {
 			pos = 0
 			curr = 0
 		}
+		c.tx.End()
 		c.wBuffer.Flush()
 	}
 }
@@ -426,10 +428,8 @@ func (c *client) processCommand() {
 	if c.cmd == nil {
 		c.notSupported()
 	} else {
-		// c.printCommand()
-		c.tx.Begin()
 		c.cmd.proc(c)
-		c.tx.End()
+		c.tx.Unlock()
 	}
 }
 

--- a/redis/server.go
+++ b/redis/server.go
@@ -328,13 +328,17 @@ func (c *client) processInput() {
 
 		// expand query buffer if full. TODO: set max query buffer length.
 		if pos == len(c.querybuf) {
-			//fmt.Println("Rewind input buffer of ", curr)
-			c.querybuf = append(c.querybuf, make([]byte, 16*1024)...)
+			nBuf := make([]byte, len(c.querybuf)*2)
+			copy(nBuf, c.querybuf[curr:pos])
+			pos -= curr
+			curr = 0
+			c.querybuf = nBuf
 		}
 		if pos == curr {
 			pos = 0
 			curr = 0
 		}
+		c.wBuffer.Flush()
 	}
 }
 
@@ -426,7 +430,6 @@ func (c *client) processCommand() {
 		c.tx.Begin()
 		c.cmd.proc(c)
 		c.tx.End()
-		c.wBuffer.Flush()
 	}
 }
 


### PR DESCRIPTION
This commit changes client behavior to call transaction End() only after completely processing a full pipeline. Performance improvements observed captured at: 
https://github.com/vmware-samples/go-redis-pmem/wiki/perf-73019