### PR TITLE
Change go-redis to accept database name as input

### DIFF
--- a/example/app.go
+++ b/example/app.go
@@ -5,8 +5,16 @@
 
 package main
 
-import "github.com/vmware-samples/go-redis-pmem/redis"
+import (
+	"log"
+	"os"
+
+	"github.com/vmware-samples/go-redis-pmem/redis"
+)
 
 func main() {
-	redis.RunServer()
+	if len(os.Args) != 2 {
+		log.Fatalf("Usage: ./app <dbName>")
+	}
+	redis.RunServer(os.Args[1])
 }

--- a/redis/server.go
+++ b/redis/server.go
@@ -64,7 +64,6 @@ type (
 )
 
 const (
-	DATABASE string = "./database"
 	PORT     string = ":6379"
 	MAGIC    int    = 0x3F4F357F7C9824B3
 
@@ -174,14 +173,14 @@ var (
 	pstart, pend uintptr
 )
 
-func RunServer() {
+func RunServer(dbName string) {
 	s := new(server)
-	s.Start()
+	s.Start(dbName)
 }
 
-func (s *server) Start() {
+func (s *server) Start(dbName string) {
 	// Initialize database
-	s.init(DATABASE)
+	s.init(dbName)
 	// accept client connections
 	tcpAddr, err := net.ResolveTCPAddr("tcp4", PORT)
 	fatalError(err)

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -151,7 +151,7 @@ func TestConsistency(t *testing.T) {
 
 	firstInit := !fileExists(database)
 
-	go redis.RunServer()
+	go redis.RunServer("./database")
 
 	// Sleep until Go Redis is ready to serve clients
 	sleepReady()


### PR DESCRIPTION
The database file used by Go Redis is hard coded now. This commit changes the `RunServer` function to accept database name as its input. This is useful while writing scripts to do performance and regressions test.